### PR TITLE
Rewritten a few parts in About of Fuel

### DIFF
--- a/pages/about-fuel/0020-what-is-fuel
+++ b/pages/about-fuel/0020-what-is-fuel
@@ -5,17 +5,18 @@
 What is Fuel?
 =============
 
-Fuel is a ready-to-install collection of the packages and scripts you need 
-to create a robust, configurable, vendor-independent OpenStack cloud in your 
-own environment. As of Fuel 3.1, Fuel Library and Fuel Web have been merged 
-into a single toolbox with options to use the UI or CLI for management. 
+Fuel is lifecycle management application that deploys multiple OpenStack environments
+from a single interface and then enables you to manage those clouds post-deployment.
+You can add nodes, remove nodes or even remove an entire cloud and return the resources
+to the pool of available resources.  Baked into Fuel are:
 
-A single OpenStack cloud consists of packages from many different open source 
-projects, each with its own requirements, installation procedures, and 
-configuration management. Fuel brings all of these projects together into a 
-single open source distribution, with components that have been tested and are 
-guaranteed to work together, and all wrapped up using scripts to help you work 
-through a single installation.
+- Mirantis reference architectures that we’ve tested and certified to ensure that
+your deployed cloud can scale, is reliable and is production quality.
+
+- An open and flexible library that enables customers to make configuration
+changes that may be more advanced or focused than the default choices within Fuel.
+This library also empowers organizations to fold additional drivers or integrations
+into the deployed environment.
 
 Simply put, Fuel is a way for you to easily configure and install an 
 OpenStack-based infrastructure in your own environment.

--- a/pages/about-fuel/0030-how-it-works.rst
+++ b/pages/about-fuel/0030-how-it-works.rst
@@ -9,24 +9,18 @@
 How Fuel Works
 ==============
 
-Fuel works on a simple premise. Rather than installing each of the 
-components that make up OpenStack directly, you instead use a configuration 
-management system like Puppet to create scripts that can provide a 
-configurable, reproducible, sharable installation process.
-
 In practice, Fuel works as follows:
 
 1. First, set up Fuel Master Node using the ISO. This process only needs to 
    be completed once per installation.
 
-2. Next, discover your virtual or physical nodes and configure your 
-   OpenStack cluster using the Fuel UI.
+2. Next, power on your virtual or physical nodes to make them discoverable by
+   Fuel Master Node and configure your OpenStack environment using the Fuel UI or CLI.
 
-3. Finally, deploy your OpenStack cluster on discovered nodes. Fuel will 
-   perform all deployment magic for you by applying pre-configured and 
-   pre-integrated Puppet manifests via Astute orchestration engine.
+3. Finally, deploy your OpenStack environment on discovered nodes. Fuel will 
+   perform all verification and deployment magic for you.
 
-Fuel is designed to enable you to maintain your cluster while giving you the 
+Fuel is designed to enable you to maintain your environment while giving you the 
 flexibility to adapt it to your own configuration.
 
 .. image:: /_images/how-it-works_svg.jpg

--- a/pages/about-fuel/0040-reference-topologies.rst
+++ b/pages/about-fuel/0040-reference-topologies.rst
@@ -14,26 +14,25 @@ deployment configurations that you can use to quickly build your own
 OpenStack cloud infrastructure. These are well-specified configurations of 
 OpenStack and its constituent components that are expertly tailored to one 
 or more common cloud use cases. Fuel provides the ability to create the 
-following cluster types without requiring extensive customization:
+following environment types without requiring extensive customization:
 
-**Simple (non-HA)**: The Simple (non-HA) installation provides an easy way 
-to install an entire OpenStack cluster without requiring the degree of 
+**Multi-node**: This simple installation provides an easy way 
+to install an entire OpenStack environment without requiring the degree of 
 increased hardware involved in ensuring high availability. 
 
-**Multi-node (HA)**: When you're ready to begin your move to production, the 
-Multi-node (HA) configuration is a straightforward way to create an OpenStack 
-cluster that provides high availability. With three controller nodes and the 
+**Multi-node with HA**: When you're ready to begin your move to production, the 
+Multi-node HA configuration is a straightforward way to create an OpenStack 
+environment that provides high availability. With three controller nodes and the 
 ability to individually specify services such as Cinder, Neutron (formerly 
-Quantum), and Swift, Fuel provides the following variations of the 
+Quantum), and Ceph, Fuel provides the following variations of the 
 Multi-node (HA) configurations:
 
-- **Compact HA**: When you choose this option, Swift will be installed on 
+- **Compact HA**: In this case Swift will be installed on 
   your controllers, reducing your hardware requirements by eliminating the need 
   for additional Swift servers while still addressing high availability 
   requirements.
 
-- **Full HA**: This option enables you to install independent Swift and Proxy
-  nodes, so that you can separate their operation from your controller nodes.
+- **Full HA**: This mode enables you to install independent Ceph and Cinder nodes.
 
 In addition to these configurations, Fuel is designed to be completely 
 customizable. For assistance on deeper customization options based on the 


### PR DESCRIPTION
- what-is-fuel
- how-it-works
- reference-topologies

Please take a look at install-guide/ folder. It has absolutely the same duplicated files which are under use now. I think we have to remove duplicated files from there and enable separated chapter "About Fuel".
